### PR TITLE
Catch NullPointerException to not print in error log

### DIFF
--- a/src/main/java/org/apache/spark/shuffle/rdma/RdmaNode.java
+++ b/src/main/java/org/apache/spark/shuffle/rdma/RdmaNode.java
@@ -356,6 +356,8 @@ class RdmaNode {
     FutureTask<Void> futureTask = new FutureTask<>(() -> {
       try {
         rdmaChannel.stop();
+      } catch (NullPointerException e) {
+        logger.trace("{} already stopped", rdmaChannel);
       } catch (InterruptedException | IOException e) {
         logger.warn("Exception caught while stopping an RdmaChannel", e);
       }


### PR DESCRIPTION
On the driver side, the active and passive RdmaChannels are essentially the same ones as they are being shared.
Due to a race condition driver <-> executor channel could be stopped first as an active or passive.

Change-Id: I4fe5131b9c076295b1f8a5f8ce6066df46fe5e6f