### PR TITLE
Use default numCompletionVectors if disni returns negative.

### DIFF
--- a/src/main/java/org/apache/spark/shuffle/rdma/RdmaNode.java
+++ b/src/main/java/org/apache/spark/shuffle/rdma/RdmaNode.java
@@ -232,8 +232,12 @@ class RdmaNode {
     };
 
     final int maxCpu = Runtime.getRuntime().availableProcessors() - 1;
+    int numCompletionVectors = listenerRdmaCmId.getVerbs().getNumCompVectors();
+    if (numCompletionVectors <= 0) {
+      numCompletionVectors = 1;
+    }
     final int maxUsableCpu = Math.min(Runtime.getRuntime().availableProcessors(),
-      listenerRdmaCmId.getVerbs().getNumCompVectors()) - 1;
+      numCompletionVectors) - 1;
     if (maxUsableCpu < maxCpu - 1) {
       logger.warn("IbvContext supports only " + (maxUsableCpu + 1) + " CPU cores, while there are" +
         " " + (maxCpu + 1) + " CPU cores in the system. This may lead to under-utilization of the" +


### PR DESCRIPTION
Fixes #31 
For some reason on the user's system `ibv_context->num_comp_vectors` returns negative number (probably not initialized). To prevent `DivisionByZeroException` we can use the default value of 1, to assign CQ processing at least to 1 CPU.